### PR TITLE
Change footer GitHub link to project URL

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -40,7 +40,7 @@
             </div>
             <footer class="footer">
                 <div class="footer-links">
-                    <a href="https://github.com/sdubinsky" target="_blank">Github</a> | 
+                    <a href="https://github.com/sdubinsky/fencing-database" target="_blank">Github</a> | 
                     <a href="https://ko-fi.com/fencingdatabase" target="_blank">Buy me coffee!</a>
                 </div>
             </footer>


### PR DESCRIPTION
The footer link was to your GitHub profile page. This commit changes it to the fencing-database project URL.

Just something I noticed and thought I could quickly fix before going back to work.